### PR TITLE
[Upstream] Fix for tinymce editor not being initialized on richtext fields

### DIFF
--- a/js/richtext.js
+++ b/js/richtext.js
@@ -123,6 +123,7 @@
 	$( document ).on( 'fm_collapsible_toggle fm_added_element fm_activate_tab fm_displayif_toggle', fm.richtextarea.add_rte_to_visible_textareas );
 	$( document ).on( 'fm_sortable_drop', fm.richtextarea.reload_editors );
 	$( document ).on( 'postbox-toggled', fm.richtextarea.should_readd_rte );
+
 	$( document ).on( 'click', '.fm-richtext .wp-switch-editor', function() {
 		var aid = this.id,
 			l = aid.length,

--- a/js/richtext.js
+++ b/js/richtext.js
@@ -113,10 +113,12 @@
 		},
 
 		should_readd_rte: function( e, el ) {
-			if ( ! $( el ).hasClass( 'closed' ) && $( el ).find( 'textarea.fm-richtext' ).length ) {
-				if ( ! $( el ).find( 'textarea' ).hasClass( 'fm-tinymce' ) ) {
-					fm.richtextarea.add_rte_to_visible_textareas();
-				}
+			if (
+				! el.classList.contains( 'closed' ) &&
+				el.querySelector( 'textarea.fm-richtext') &&
+				! el.querySelector( 'textarea.fm-tinymce' )
+			) {
+				fm.richtextarea.add_rte_to_visible_textareas();
 			}
 		}
 	}

--- a/js/richtext.js
+++ b/js/richtext.js
@@ -110,11 +110,19 @@
 			if ( 'html' === core_editor_state || 'tinymce' === core_editor_state ) {
 				setUserSetting( 'editor', core_editor_state );
 			}
+		},
+
+		should_readd_rte: function( e, el ) {
+			if ( ! $( el ).hasClass( 'closed' ) && $( el ).find( 'textarea.fm-richtext' ).length ) {
+				if ( ! $( el ).find( 'textarea' ).hasClass( 'fm-tinymce' ) ) {
+					fm.richtextarea.add_rte_to_visible_textareas();
+				}
+			}
 		}
 	}
 	$( document ).on( 'fm_collapsible_toggle fm_added_element fm_activate_tab fm_displayif_toggle', fm.richtextarea.add_rte_to_visible_textareas );
 	$( document ).on( 'fm_sortable_drop', fm.richtextarea.reload_editors );
-
+	$( document ).on( 'postbox-toggled', fm.richtextarea.should_readd_rte );
 	$( document ).on( 'click', '.fm-richtext .wp-switch-editor', function() {
 		var aid = this.id,
 			l = aid.length,

--- a/php/class-fieldmanager-richtextarea.php
+++ b/php/class-fieldmanager-richtextarea.php
@@ -82,7 +82,7 @@ class Fieldmanager_RichTextArea extends Fieldmanager_Field {
 	 */
 	public function __construct( $label = '', $options = array() ) {
 		$this->sanitize = array( $this, 'sanitize' );
-		fm_add_script( 'fm_richtext', 'js/richtext.js', array( 'jquery', 'fieldmanager_script' ), '1.0.8' );
+		fm_add_script( 'fm_richtext', 'js/richtext.js', array( 'jquery', 'fieldmanager_script' ), '1.0.9' );
 
 		parent::__construct( $label, $options );
 	}


### PR DESCRIPTION
Cherry-picked version of https://github.com/alleyinteractive/wordpress-fieldmanager/pull/628 without all the new stuff so we can avoid deprecation warnings for `Fieldmanager_Context_Page` (see #157).

## QA

You'll have to check this out locally:

```sh
# From your local environment root
cd wp-content/plugins/wordpress-fieldmanager
git fetch
git checkout spiritedmedia-collapsed-richtext-tinymce-reinit
```

Is the issue described in https://github.com/spiritedmedia/spiritedmedia/pull/2591#issuecomment-388175593 fixed?