### PR TITLE
[Upstream PR #658] Potential fix for fm_renumber and radios bug

### DIFF
--- a/js/fieldmanager.js
+++ b/js/fieldmanager.js
@@ -69,6 +69,7 @@ var init_label_macros = function() {
 }
 
 var fm_renumber = function( $wrappers ) {
+	var fmtemp = parseInt( Math.random() * 100000, 10 );
 	$wrappers.each( function() {
 		var level_pos = $( this ).data( 'fm-array-position' ) - 0;
 		var order = 0;
@@ -85,7 +86,8 @@ var fm_renumber = function( $wrappers ) {
 						if ( parts[ level_pos ] != order ) {
 							parts[ level_pos ] = order;
 							var new_fname = parts[ 0 ] + '[' + parts.slice( 1 ).join( '][' ) + ']';
-							$( this ).attr( 'name', new_fname );
+							// Rename the field and add a temporary prefix to prevent name collisions.
+							$( this ).attr( 'name', 'fmtemp_' + ( ++fmtemp ).toString() + '_' + new_fname );
 							if ( $( this ).attr( 'id' ) && $( this ).attr( 'id' ).match( '-proto' ) && ! new_fname.match( 'proto' ) ) {
 								$( this ).attr( 'id', 'fm-edit-dynamic-' + dynamic_seq );
 								if ( $( this ).parent().hasClass( 'fm-option' ) ) {
@@ -111,6 +113,11 @@ var fm_renumber = function( $wrappers ) {
 		}
 		$( this ).find( '.fm-wrapper' ).each( function() {
 			fm_renumber( $( this ) );
+		} );
+
+		// Remove temporary name prefix in renumbered fields.
+		$( '.fm-element[name^="fmtemp_"], .fm-incrementable[name^="fmtemp_"]' ).each( function() {
+			$( this ).attr( 'name', $( this ).attr( 'name' ).replace( /^fmtemp_\d+_/, '' ) );
 		} );
 	} );
 }

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -401,8 +401,8 @@ abstract class Fieldmanager_Field {
 
 		// Only enqueue base assets once, and only when we have a field.
 		if ( ! self::$enqueued_base_assets ) {
-			fm_add_script( 'fieldmanager_script', 'js/fieldmanager.js', array( 'jquery', 'jquery-ui-sortable' ), '1.0.8' );
-			fm_add_style( 'fieldmanager_style', 'css/fieldmanager.css', array(), '1.0.4' );
+			fm_add_script( 'fieldmanager_script', 'js/fieldmanager.js', array( 'jquery', 'jquery-ui-sortable' ), '1.2.0' );
+			fm_add_style( 'fieldmanager_style', 'css/fieldmanager.css', array(), '1.2.0' );
 			self::$enqueued_base_assets = true;
 		}
 	}


### PR DESCRIPTION
Cherry-picked version of https://github.com/alleyinteractive/wordpress-fieldmanager/pull/658

Fixes the issue described in https://github.com/alleyinteractive/wordpress-fieldmanager/issues/548

I'm cherry-picking because of merging because we are trying to avoid the deprecation notices for `Fieldmanager_Context_Page` and `add_submenu_page()`.